### PR TITLE
feat: support context menu to manage StatusBarItem visibility

### DIFF
--- a/demo/StatusBarDemo/ViewModels/MainViewModel.cs
+++ b/demo/StatusBarDemo/ViewModels/MainViewModel.cs
@@ -33,6 +33,9 @@ public partial class MainViewModel : ViewModelBase
     [ObservableProperty]
     private AvaloniaList<string> _disabledItems;
 
+    [ObservableProperty]
+    private bool _disableContextMenu;
+
     public MainViewModel()
     {
         DisabledItems = [];

--- a/demo/StatusBarDemo/ViewModels/MainViewModel.cs
+++ b/demo/StatusBarDemo/ViewModels/MainViewModel.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia;
+using Avalonia.Collections;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
@@ -28,8 +30,13 @@ public partial class MainViewModel : ViewModelBase
     private readonly StatusBarItem _logoItem;
     private readonly StatusBarItem _counterItem;
 
+    [ObservableProperty]
+    private AvaloniaList<string> _disabledItems;
+
     public MainViewModel()
     {
+        DisabledItems = [];
+
         _modeItem = StatusBarManager.CreateStatusBarItem("mode");
         _gitBranchItem = StatusBarManager.CreateStatusBarItem("git-branch");
         _gitStatusItem = StatusBarManager.CreateStatusBarItem("git-status");
@@ -63,12 +70,37 @@ public partial class MainViewModel : ViewModelBase
 
     private void InitLogoItem()
     {
-        _logoItem.Content = new Image
+        var image = new Image
         {
             Source = new Bitmap(AssetLoader.Open(new Uri("avares://StatusBarDemo/Assets/avalonia-logo.ico"))),
             Width = 18,
             Height = 18,
         };
+
+        var showAboutPopupCommand = new RelayCommand(() =>
+        {
+            var flyout = new Flyout()
+            {
+                Content = new TextBlock()
+                {
+                    Text = "Avalonia StatusBar Demo",
+                    FontSize = 18,
+                    FontWeight = FontWeight.Bold,
+                },
+                ShowMode = FlyoutShowMode.TransientWithDismissOnPointerMoveAway,
+            };
+            flyout.ShowAt(image, true);
+        });
+
+        image.ContextMenu = new ContextMenu
+        {
+            Items =
+            {
+                new MenuItem { Header = "_About", Command = showAboutPopupCommand },
+            },
+        };
+
+        _logoItem.Content = image;
         _logoItem.Show();
     }
 
@@ -232,5 +264,16 @@ public partial class MainViewModel : ViewModelBase
         }
 
         await Task.Delay(100);
+    }
+
+    [RelayCommand]
+    private void EnableItem(string? itemId)
+    {
+        if (string.IsNullOrEmpty(itemId))
+        {
+            return;
+        }
+
+        DisabledItems.Remove(itemId);
     }
 }

--- a/demo/StatusBarDemo/ViewModels/MainViewModel.cs
+++ b/demo/StatusBarDemo/ViewModels/MainViewModel.cs
@@ -1,17 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using StatusBar.Avalonia;
-using StatusBar.Avalonia.Themes;
 
 namespace StatusBarDemo.ViewModels;
 
@@ -131,6 +127,7 @@ public partial class MainViewModel : ViewModelBase
     private void InitModeItem()
     {
         _modeItem.Color = Brushes.Black;
+        _modeItem.Name = "Vim Mode";
         _modeItem.Click = () =>
             setMode(
                 _modeItem.Text switch
@@ -161,6 +158,7 @@ public partial class MainViewModel : ViewModelBase
     private void InitGitItem()
     {
         _gitBranchItem.Text = "$(git-branch) master";
+        _gitBranchItem.Name = "Git Branch";
         _gitBranchItem.ToolTip = "Current branch";
         _gitBranchItem.Click = () =>
         {
@@ -171,6 +169,7 @@ public partial class MainViewModel : ViewModelBase
 
         _gitStatusItem.Text = "↑ 1 ↓ 0 ! 0";
         _gitStatusItem.ToolTip = "Sync with remote";
+        _gitStatusItem.Name = "Git Status";
         _gitStatusItem.Click = () =>
         {
             if (_gitStatusItem.Text == "$(sync~spin) ↑ 1 ↓ 0 ! 0")
@@ -191,12 +190,14 @@ public partial class MainViewModel : ViewModelBase
     private void InitLineBreakItem()
     {
         _lineBreakItem.Text = "LF";
+        _lineBreakItem.Name = "Line Break";
         _lineBreakItem.Show();
     }
 
     private void InitEncodingItem()
     {
         _encodingItem.Text = "UTF-8";
+        _encodingItem.Name = "File Encoding";
         _encodingItem.Show();
     }
 

--- a/demo/StatusBarDemo/Views/MainView.axaml
+++ b/demo/StatusBarDemo/Views/MainView.axaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:status="https://github.com/xiyaowong/StatusBar.Avalonia"
+             xmlns:views="clr-namespace:StatusBarDemo.Views"
              xmlns:vm="clr-namespace:StatusBarDemo.ViewModels"
              d:DesignHeight="450"
              d:DesignWidth="1200"
@@ -32,16 +33,14 @@
                 <Button Command="{Binding SimulateSettingPythonEnvironmentCommand}" Content="Setup Python" />
             </StackPanel>
 
-
             <StackPanel Grid.Column="1"
                         Orientation="Horizontal"
                         Spacing="10">
                 <StackPanel Orientation="Horizontal" Spacing="5">
                     <TextBlock VerticalAlignment="Center"
                                FontSize="16"
-                               FontWeight="Bold">
-                        ColorTheme
-                    </TextBlock>
+                               FontWeight="Bold"
+                               Text="ColorTheme" />
                     <ComboBox SelectedIndex="0" SelectionChanged="ColorThemeChanged">
                         <ComboBoxItem Content="{x:Static status:ColorTheme.DarkPlus}" />
                         <ComboBoxItem Content="{x:Static status:ColorTheme.OneDark}" />
@@ -51,9 +50,8 @@
                 <StackPanel Orientation="Horizontal" Spacing="5">
                     <TextBlock VerticalAlignment="Center"
                                FontSize="16"
-                               FontWeight="Bold">
-                        Theme
-                    </TextBlock>
+                               FontWeight="Bold"
+                               Text="Theme" />
                     <ComboBox SelectedIndex="0" SelectionChanged="ThemeChanged">
                         <ComboBoxItem Content="{x:Static ThemeVariant.Dark}" />
                         <ComboBoxItem Content="{x:Static ThemeVariant.Light}" />
@@ -62,7 +60,39 @@
             </StackPanel>
         </Grid>
 
-        <status:StatusBarContainer Name="_StatusBarContainer" Grid.Row="2" />
+        <StackPanel Grid.Row="1"
+                    Margin="10"
+                    VerticalAlignment="Top"
+                    Orientation="Horizontal">
+            <TextBlock VerticalAlignment="Bottom"
+                       FontSize="16"
+                       FontWeight="Bold"
+                       IsVisible="{Binding DisabledItems.Count}"
+                       Text="Disabled items (click to enable): " />
+            <TextBlock VerticalAlignment="Bottom"
+                       Foreground="LightGray"
+                       IsVisible="{Binding !DisabledItems.Count}"
+                       Text="Right click the status bar to enable/disable items." />
+            <ItemsControl ItemsSource="{Binding DisabledItems}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="5" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <!--  ReSharper disable once Xaml.PossibleNullReferenceException  -->
+                        <Button Command="{Binding RelativeSource={RelativeSource AncestorType=views:MainView}, Path=((vm:MainViewModel)DataContext).EnableItemCommand}"
+                                CommandParameter="{Binding}"
+                                Content="{Binding}" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+
+        <status:StatusBarContainer Name="_StatusBarContainer"
+                                   Grid.Row="2"
+                                   DisabledItems="{Binding DisabledItems}" />
     </Grid>
 
 </UserControl>

--- a/demo/StatusBarDemo/Views/MainView.axaml
+++ b/demo/StatusBarDemo/Views/MainView.axaml
@@ -60,10 +60,8 @@
             </StackPanel>
         </Grid>
 
-        <StackPanel Grid.Row="1"
-                    Margin="10"
-                    VerticalAlignment="Top"
-                    Orientation="Horizontal">
+        <StackPanel Grid.Row="1" Margin="10" VerticalAlignment="Top">
+            <CheckBox IsChecked="{Binding DisableContextMenu}" Content="Disable the default context menu"></CheckBox>
             <TextBlock VerticalAlignment="Bottom"
                        FontSize="16"
                        FontWeight="Bold"
@@ -82,9 +80,10 @@
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <!--  ReSharper disable once Xaml.PossibleNullReferenceException  -->
-                        <Button Command="{Binding RelativeSource={RelativeSource AncestorType=views:MainView}, Path=((vm:MainViewModel)DataContext).EnableItemCommand}"
-                                CommandParameter="{Binding}"
-                                Content="{Binding}" />
+                        <Button
+                            Command="{Binding RelativeSource={RelativeSource AncestorType=views:MainView}, Path=((vm:MainViewModel)DataContext).EnableItemCommand}"
+                            CommandParameter="{Binding}"
+                            Content="{Binding}" />
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
@@ -92,6 +91,7 @@
 
         <status:StatusBarContainer Name="_StatusBarContainer"
                                    Grid.Row="2"
+                                   DisableDefaultContextMenu="{Binding DisableContextMenu}"
                                    DisabledItems="{Binding DisabledItems}" />
     </Grid>
 

--- a/demo/StatusBarDemo/Views/MainView.axaml
+++ b/demo/StatusBarDemo/Views/MainView.axaml
@@ -60,8 +60,10 @@
             </StackPanel>
         </Grid>
 
-        <StackPanel Grid.Row="1" Margin="10" VerticalAlignment="Top">
-            <CheckBox IsChecked="{Binding DisableContextMenu}" Content="Disable the default context menu"></CheckBox>
+        <StackPanel Grid.Row="1"
+                    Margin="10"
+                    VerticalAlignment="Top">
+            <CheckBox Content="Disable the default context menu" IsChecked="{Binding DisableContextMenu}" />
             <TextBlock VerticalAlignment="Bottom"
                        FontSize="16"
                        FontWeight="Bold"
@@ -80,10 +82,9 @@
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <!--  ReSharper disable once Xaml.PossibleNullReferenceException  -->
-                        <Button
-                            Command="{Binding RelativeSource={RelativeSource AncestorType=views:MainView}, Path=((vm:MainViewModel)DataContext).EnableItemCommand}"
-                            CommandParameter="{Binding}"
-                            Content="{Binding}" />
+                        <Button Command="{Binding RelativeSource={RelativeSource AncestorType=views:MainView}, Path=((vm:MainViewModel)DataContext).EnableItemCommand}"
+                                CommandParameter="{Binding}"
+                                Content="{Binding}" />
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>

--- a/demo/StatusBarDemo/Views/MainWindow.axaml
+++ b/demo/StatusBarDemo/Views/MainWindow.axaml
@@ -7,7 +7,7 @@
         xmlns:vm="using:StatusBarDemo.ViewModels"
         Title="StatusBarDemo"
         Width="1200"
-        Height="600"
+        Height="450"
         d:DesignHeight="450"
         d:DesignWidth="800"
         ExtendClientAreaTitleBarHeightHint="30"

--- a/src/StatusBar.Avalonia/Controls/Codicon.axaml
+++ b/src/StatusBar.Avalonia/Controls/Codicon.axaml
@@ -7,8 +7,8 @@
         <StackPanel Spacing="10">
             <TextBlock Foreground="Aqua">
                 <local:Codicon Foreground="Red"
-                                  Icon="gear"
-                                  Spin="True" />
+                               Icon="gear"
+                               Spin="True" />
                 <local:Codicon Foreground="Red" Icon="&#xea60;" />
                 <local:Codicon Icon="sync" Spin="True" />
                 <local:Codicon Icon="loading" Spin="True" />

--- a/src/StatusBar.Avalonia/Controls/Codicon.axaml.cs
+++ b/src/StatusBar.Avalonia/Controls/Codicon.axaml.cs
@@ -42,9 +42,7 @@ internal class Codicon : TemplatedControl
         set => SetValue(IconProperty, value);
     }
 
-    public static readonly StyledProperty<bool> SpinProperty = AvaloniaProperty.Register<Codicon, bool>(
-        nameof(Spin)
-    );
+    public static readonly StyledProperty<bool> SpinProperty = AvaloniaProperty.Register<Codicon, bool>(nameof(Spin));
 
     public bool Spin
     {

--- a/src/StatusBar.Avalonia/Controls/StatusBarContainer.axaml.cs
+++ b/src/StatusBar.Avalonia/Controls/StatusBarContainer.axaml.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
 using Avalonia;
+using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Primitives.PopupPositioning;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.VisualTree;
 
 namespace StatusBar.Avalonia.Controls;
 
@@ -22,15 +28,43 @@ public sealed class StatusBarContainer : TemplatedControl
 
     private const string PC_HasBackground = ":has-background";
 
-    private StackPanel _leftContainer = null!;
-    private StackPanel _centerContainer = null!;
-    private StackPanel _rightContainer = null!;
+    public static readonly StyledProperty<BoxShadows> BoxShadowProperty =
+        Border.BoxShadowProperty.AddOwner<StatusBarContainer>();
+
+    public static readonly DirectProperty<StatusBarContainer, AvaloniaList<string>> DisabledItemsProperty =
+        AvaloniaProperty.RegisterDirect<StatusBarContainer, AvaloniaList<string>>(
+            nameof(DisabledItems),
+            o => o.DisabledItems,
+            (o, v) => o.DisabledItems = v
+        );
+
+    public AvaloniaList<string> DisabledItems
+    {
+        get;
+        set => SetAndRaise(DisabledItemsProperty, ref field, value);
+    } = [];
+
+    public BoxShadows BoxShadow
+    {
+        get => GetValue(BoxShadowProperty);
+        set => SetValue(BoxShadowProperty, value);
+    }
+
+    private StackPanel? _leftContainer;
+    private StackPanel? _centerContainer;
+    private StackPanel? _rightContainer;
 
     private readonly ConcurrentQueue<StatusBarEntry> _pendingItems = new();
 
     static StatusBarContainer()
     {
         HeightProperty.OverrideDefaultValue(typeof(StatusBarContainer), 28);
+    }
+
+    public StatusBarContainer()
+    {
+        DisabledItems.CollectionChanged -= DisabledItems_CollectionChanged;
+        DisabledItems.CollectionChanged += DisabledItems_CollectionChanged;
     }
 
     /// <inheritdoc />
@@ -41,6 +75,8 @@ public sealed class StatusBarContainer : TemplatedControl
         _leftContainer = e.NameScope.Get<StackPanel>(PART_LeftContainer);
         _centerContainer = e.NameScope.Get<StackPanel>(PART_CenterContainer);
         _rightContainer = e.NameScope.Get<StackPanel>(PART_RightContainer);
+
+        ContextRequested += OnContextRequested;
     }
 
     /// <inheritdoc />
@@ -54,35 +90,40 @@ public sealed class StatusBarContainer : TemplatedControl
         }
     }
 
-    internal void AddStatusBarEntry(StatusBarEntry newItem)
+    internal void AddStatusBarEntry(StatusBarEntry entry)
     {
-        ArgumentNullException.ThrowIfNull(newItem);
+        ArgumentNullException.ThrowIfNull(entry);
 
         if (!IsLoaded)
         {
-            _pendingItems.Enqueue(newItem);
+            _pendingItems.Enqueue(entry);
             return;
         }
 
-        var targetContainer = newItem.Alignment switch
+        var targetContainer = entry.Alignment switch
         {
             StatusBarAlignment.Center => _centerContainer,
             StatusBarAlignment.Right => _rightContainer,
             _ => _leftContainer,
         };
 
-        var insertIndex = GetInsertIndex(targetContainer.Children, newItem.Priority);
-        targetContainer.Children.Insert(insertIndex, newItem);
+        var insertIndex = GetInsertIndex(targetContainer!.Children, entry.Priority);
+        targetContainer.Children.Insert(insertIndex, entry);
 
-        newItem.Disposed += OnStatusBarItemDisposed;
+        entry.Disposed += OnStatusBarItemDisposed;
+
+        if (DisabledItems.Contains(entry.Id))
+        {
+            entry.IsVisible = false;
+        }
 
         return;
 
-        static int GetInsertIndex(IList<Control> items, int newItemPriority)
+        static int GetInsertIndex(IList<Control> items, int priority)
         {
             for (var i = 0; i < items.Count; i++)
             {
-                if (items[i] is StatusBarEntry existingItem && existingItem.Priority < newItemPriority)
+                if (items[i] is StatusBarEntry existingItem && existingItem.Priority < priority)
                 {
                     return i;
                 }
@@ -95,21 +136,176 @@ public sealed class StatusBarContainer : TemplatedControl
     private void OnStatusBarItemDisposed(object? sender, EventArgs e)
     {
         if (sender is not StatusBarEntry item)
+        {
             return;
+        }
 
         item.Disposed -= OnStatusBarItemDisposed;
 
-        _leftContainer.Children.Remove(item);
-        _centerContainer.Children.Remove(item);
-        _rightContainer.Children.Remove(item);
+        _leftContainer!.Children.Remove(item);
+        _centerContainer!.Children.Remove(item);
+        _rightContainer!.Children.Remove(item);
     }
 
-    public static readonly StyledProperty<BoxShadows> BoxShadowProperty =
-        Border.BoxShadowProperty.AddOwner<StatusBarContainer>();
-
-    public BoxShadows BoxShadow
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
-        get => GetValue(BoxShadowProperty);
-        set => SetValue(BoxShadowProperty, value);
+        base.OnPropertyChanged(change);
+
+        if (change.Property == DisabledItemsProperty)
+        {
+            var oldItems = change.OldValue as AvaloniaList<string>;
+            var newItems = change.NewValue as AvaloniaList<string>;
+
+            if (oldItems is not null)
+            {
+                oldItems.CollectionChanged -= DisabledItems_CollectionChanged;
+            }
+
+            if (newItems is not null)
+            {
+                newItems.CollectionChanged -= DisabledItems_CollectionChanged;
+                newItems.CollectionChanged += DisabledItems_CollectionChanged;
+            }
+
+            OnDisabledItemsChanged(oldItems, newItems);
+        }
+    }
+
+    private void DisabledItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnDisabledItemsChanged(e.OldItems, e.NewItems);
+    }
+
+    private void OnDisabledItemsChanged(IList? changeOldValue, IList? changeNewValue)
+    {
+        var oldItems = changeOldValue?.Cast<string>().ToList() ?? [];
+        var newItems = changeNewValue?.Cast<string>().ToList() ?? [];
+
+        var itemsToShow = oldItems.Where(x => !newItems.Contains(x)).ToArray();
+        var itemsToHide = newItems.Where(x => !oldItems.Contains(x)).ToArray();
+
+        if (itemsToShow.Length == 0 && itemsToHide.Length == 0)
+            return;
+
+        var allItems = _leftContainer
+            ?.Children.OfType<StatusBarEntry>()
+            .Concat(_centerContainer?.Children.OfType<StatusBarEntry>() ?? [])
+            .Concat(_rightContainer?.Children.OfType<StatusBarEntry>() ?? []);
+
+        if (allItems == null)
+            return;
+
+        foreach (var item in allItems)
+        {
+            if (itemsToShow.Contains(item.Id))
+            {
+                item.IsVisible = true;
+            }
+            else if (itemsToHide.Contains(item.Id))
+            {
+                item.IsVisible = false;
+            }
+        }
+    }
+
+    private void OnContextRequested(object? sender, ContextRequestedEventArgs args)
+    {
+        if (args.Handled)
+        {
+            return;
+        }
+
+        var sourceControl = (Control)args.Source!;
+
+        // build the context menu
+
+        var activeEntry = sourceControl.FindAncestorOfType<StatusBarEntry>(true);
+        if (activeEntry?.IsTemporary == true)
+            activeEntry = null;
+
+        var menu = new ContextMenu
+        {
+            Placement = PlacementMode.Custom,
+            CustomPopupPlacementCallback = parameters =>
+            {
+                var offsetX = args.TryGetPosition((Control)parameters.Target, out var position) ? position.X : 0;
+                var offsetY = -parameters.PopupSize.Height / 2;
+
+                parameters.Anchor = PopupAnchor.TopLeft;
+                parameters.Offset = parameters.Offset.WithY(offsetY).WithX(offsetX);
+            },
+        };
+
+        foreach (
+            var entry in _leftContainer
+                .Children.OfType<StatusBarEntry>()
+                .Concat(_centerContainer.Children.OfType<StatusBarEntry>())
+                .Concat(_rightContainer.Children.OfType<StatusBarEntry>())
+                .Where(e => !e.IsTemporary)
+        )
+        {
+            if (entry == activeEntry)
+            {
+                continue;
+            }
+
+            menu.Items.Add(
+                new MenuItem()
+                {
+                    // TODO: display name
+                    Header = entry.Id,
+                    IsChecked = !DisabledItems.Contains(entry.Id),
+                    Tag = entry.Id,
+                    ToggleType = MenuItemToggleType.CheckBox,
+                }
+            );
+        }
+
+        if (activeEntry != null)
+        {
+            menu.Items.Add("-");
+
+            var hideItem = new MenuItem { Header = $"Hide '{activeEntry.Id}'" };
+            hideItem.Click += (_, _) => DisabledItems.Add(activeEntry.Id);
+            menu.Items.Add(hideItem);
+        }
+
+        menu.Closed += delegate
+        {
+            var enabledItems = new List<string>();
+            var disabledItems = new List<string>();
+
+            foreach (var menuItem in menu.Items.OfType<MenuItem>())
+            {
+                if (menuItem.Tag is not string id)
+                {
+                    continue;
+                }
+
+                switch (menuItem)
+                {
+                    case { IsChecked: true }:
+                        enabledItems.Add(id);
+                        break;
+                    case { IsChecked: false }:
+                        disabledItems.Add(id);
+                        break;
+                }
+            }
+
+            var disabledItemsToAdd = disabledItems.Where(x => !DisabledItems.Contains(x)).ToArray();
+            if (disabledItemsToAdd.Length > 0)
+            {
+                DisabledItems.AddRange(disabledItemsToAdd);
+            }
+
+            if (enabledItems.Count > 0)
+            {
+                DisabledItems.RemoveAll(enabledItems);
+            }
+        };
+
+        menu.Open(sourceControl);
     }
 }

--- a/src/StatusBar.Avalonia/Controls/StatusBarContainer.axaml.cs
+++ b/src/StatusBar.Avalonia/Controls/StatusBarContainer.axaml.cs
@@ -265,8 +265,7 @@ public sealed class StatusBarContainer : TemplatedControl
             menu.Items.Add(
                 new MenuItem()
                 {
-                    // TODO: display name
-                    Header = entry.Id,
+                    Header = entry.DisplayName ?? entry.Id,
                     IsChecked = !DisabledItems.Contains(entry.Id),
                     Tag = entry.Id,
                     ToggleType = MenuItemToggleType.CheckBox,
@@ -278,7 +277,7 @@ public sealed class StatusBarContainer : TemplatedControl
         {
             menu.Items.Add("-");
 
-            var hideItem = new MenuItem { Header = $"Hide '{activeEntry.Id}'" };
+            var hideItem = new MenuItem { Header = $"Hide '{activeEntry.DisplayName ?? activeEntry.Id}'" };
             hideItem.Click += (_, _) => DisabledItems.Add(activeEntry.Id);
             menu.Items.Add(hideItem);
         }

--- a/src/StatusBar.Avalonia/Controls/StatusBarContainer.axaml.cs
+++ b/src/StatusBar.Avalonia/Controls/StatusBarContainer.axaml.cs
@@ -38,16 +38,27 @@ public sealed class StatusBarContainer : TemplatedControl
             (o, v) => o.DisabledItems = v
         );
 
+    public static readonly StyledProperty<bool> DisableDefaultContextMenuProperty = AvaloniaProperty.Register<
+        StatusBarContainer,
+        bool
+    >(nameof(DisableDefaultContextMenu));
+
+    public BoxShadows BoxShadow
+    {
+        get => GetValue(BoxShadowProperty);
+        set => SetValue(BoxShadowProperty, value);
+    }
+
     public AvaloniaList<string> DisabledItems
     {
         get;
         set => SetAndRaise(DisabledItemsProperty, ref field, value);
     } = [];
 
-    public BoxShadows BoxShadow
+    public bool DisableDefaultContextMenu
     {
-        get => GetValue(BoxShadowProperty);
-        set => SetValue(BoxShadowProperty, value);
+        get => GetValue(DisableDefaultContextMenuProperty);
+        set => SetValue(DisableDefaultContextMenuProperty, value);
     }
 
     private StackPanel? _leftContainer;
@@ -76,6 +87,7 @@ public sealed class StatusBarContainer : TemplatedControl
         _centerContainer = e.NameScope.Get<StackPanel>(PART_CenterContainer);
         _rightContainer = e.NameScope.Get<StackPanel>(PART_RightContainer);
 
+        ContextRequested -= OnContextRequested;
         ContextRequested += OnContextRequested;
     }
 
@@ -211,7 +223,7 @@ public sealed class StatusBarContainer : TemplatedControl
 
     private void OnContextRequested(object? sender, ContextRequestedEventArgs args)
     {
-        if (args.Handled)
+        if (DisableDefaultContextMenu || args.Handled)
         {
             return;
         }
@@ -238,10 +250,10 @@ public sealed class StatusBarContainer : TemplatedControl
         };
 
         foreach (
-            var entry in _leftContainer
+            var entry in _leftContainer!
                 .Children.OfType<StatusBarEntry>()
-                .Concat(_centerContainer.Children.OfType<StatusBarEntry>())
-                .Concat(_rightContainer.Children.OfType<StatusBarEntry>())
+                .Concat(_centerContainer!.Children.OfType<StatusBarEntry>())
+                .Concat(_rightContainer!.Children.OfType<StatusBarEntry>())
                 .Where(e => !e.IsTemporary)
         )
         {

--- a/src/StatusBar.Avalonia/Controls/StatusBarEntry.axaml
+++ b/src/StatusBar.Avalonia/Controls/StatusBarEntry.axaml
@@ -19,6 +19,7 @@
                         MinHeight="{Binding $parent[local:StatusBarContainer].Height}"
                         Padding="{DynamicResource StatusBarEntryRootPadding}"
                         VerticalAlignment="Center"
+                        IsHitTestVisible="True"
                         IsVisible="{TemplateBinding IsShow}"
                         ToolTip.Placement="Top"
                         ToolTip.ServiceEnabled="{TemplateBinding ToolTip,
@@ -67,7 +68,7 @@
         <!--  // Root //  -->
 
         <Style Selector="^ /template/ Border#PART_Root">
-            <Setter Property="Background" Value="{Binding $parent[local:StatusBarContainer].Background}" />
+            <Setter Property="Background" Value="Transparent" />
         </Style>
 
         <Style Selector="^:has-click /template/ Border#PART_Root">

--- a/src/StatusBar.Avalonia/Controls/StatusBarEntry.axaml.cs
+++ b/src/StatusBar.Avalonia/Controls/StatusBarEntry.axaml.cs
@@ -33,6 +33,11 @@ internal partial class StatusBarEntry : ContentControl
         nameof(Id)
     );
 
+    public static readonly StyledProperty<string?> DisplayNameProperty = AvaloniaProperty.Register<
+        StatusBarEntry,
+        string?
+    >(nameof(DisplayName));
+
     /// <summary>
     /// Defines the <see cref="Alignment"/> avalonia property.
     /// </summary>
@@ -111,6 +116,12 @@ internal partial class StatusBarEntry : ContentControl
     {
         get => GetValue(IdProperty);
         set => SetValue(IdProperty, value);
+    }
+
+    public string? DisplayName
+    {
+        get => GetValue(DisplayNameProperty);
+        set => SetValue(DisplayNameProperty, value);
     }
 
     /// <summary>

--- a/src/StatusBar.Avalonia/StatusBarItem.cs
+++ b/src/StatusBar.Avalonia/StatusBarItem.cs
@@ -17,6 +17,7 @@ public sealed class StatusBarItem : IDisposable
     internal StatusBarItem(StatusBarEntry entry)
     {
         Id = entry.Id;
+        Name = entry.DisplayName;
         Alignment = entry.Alignment;
         Priority = entry.Priority;
         Text = entry.Text;
@@ -44,6 +45,30 @@ public sealed class StatusBarItem : IDisposable
     /// Higher value means the item should be shown more to the left.
     /// </summary>
     public int Priority { get; private set; }
+
+    /// <summary>
+    /// The name of the entry, like 'Python Language Indicator', 'Git Status' etc.
+    /// Try to keep the length of the name short, yet descriptive enough
+    /// that users can understand what the status bar item is about.
+    /// </summary>
+    public string? Name
+    {
+        get;
+        set
+        {
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+            if (_entry == null)
+                return;
+
+            field = value;
+
+            if (Dispatcher.UIThread.CheckAccess())
+                _entry.DisplayName = value;
+            else
+                Dispatcher.UIThread.Invoke(() => _entry.DisplayName = value);
+        }
+    }
 
     /// <summary>
     /// The text to show for the entry. You can embed icons in the text by leveraging the syntax:

--- a/src/StatusBar.Avalonia/StatusBarManager.cs
+++ b/src/StatusBar.Avalonia/StatusBarManager.cs
@@ -11,27 +11,27 @@ public class StatusBarManager
 {
     private readonly ConcurrentQueue<StatusBarEntry> _pendingItems = new();
 
-    private StatusBarContainer? _statusBarContainer;
+    private StatusBarContainer? _container;
 
     public StatusBarManager() { }
 
-    public StatusBarManager(StatusBarContainer statusBarContainer)
+    public StatusBarManager(StatusBarContainer container)
     {
-        _statusBarContainer = statusBarContainer;
+        _container = container;
     }
 
     public void BindContainer(StatusBarContainer statusBarContainer)
     {
-        if (_statusBarContainer != null)
+        if (_container != null)
         {
             throw new InvalidOperationException($"{nameof(StatusBarManager)} already has a container.");
         }
 
-        _statusBarContainer = statusBarContainer;
+        _container = statusBarContainer;
 
         while (_pendingItems.TryDequeue(out var item))
         {
-            _statusBarContainer.AddStatusBarEntry(item);
+            _container.AddStatusBarEntry(item);
         }
     }
 
@@ -148,7 +148,7 @@ public class StatusBarManager
 
     private void AddStatusBarEntry(StatusBarEntry entry)
     {
-        if (_statusBarContainer == null)
+        if (_container == null)
         {
             _pendingItems.Enqueue(entry);
             return;
@@ -156,10 +156,10 @@ public class StatusBarManager
 
         while (_pendingItems.TryDequeue(out var item))
         {
-            _statusBarContainer.AddStatusBarEntry(item);
+            _container.AddStatusBarEntry(item);
         }
 
-        _statusBarContainer.AddStatusBarEntry(entry);
+        _container.AddStatusBarEntry(entry);
     }
 }
 


### PR DESCRIPTION
- Use `DisabledItems` to manage StatusBarItem visibility
- Use `DisableDefaultContextMenu` to disable the default contextmenu
- Allow set the display name of the status bar entry

close #3

